### PR TITLE
Refactor Connection and ConnectionManager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 .clangd
 build
 compile_commands.json
-compile_flags.json
+compile_flags.txt
 
 # VIM
 *.swp

--- a/src/memo/Reply.hpp
+++ b/src/memo/Reply.hpp
@@ -2,6 +2,7 @@
 #include "memo/Header.hpp"
 #include <boost/asio.hpp>
 
+#include <memory>
 #include <vector>
 #include <string>
 
@@ -10,6 +11,8 @@ namespace memo {
 class Reply
 {
 public:
+    using Ptr = std::shared_ptr<Reply>;
+
     enum Status {
         ok = 200,
         created = 201,

--- a/src/memo/manager/ConnectionManager.cpp
+++ b/src/memo/manager/ConnectionManager.cpp
@@ -1,30 +1,51 @@
 #include "memo/manager/ConnectionManager.hpp"
 
-#include <iostream>
 #include <boost/bind.hpp>
+
+#include <iostream>
+#include <exception>
 
 namespace memo {
 namespace manager {
 
-void ConnectionManager::start(const Connection::Ptr& iConnection)
+Connection& ConnectionManager::getConnectionById(const std::string& iId)
 {
-    std::cout << "[Manager] Starting new connection..." << std::endl;
-    connections.insert(iConnection);
-    iConnection->start();
+    auto aIt = connections.find(iId);
+    if (aIt != std::end(connections))
+        return *aIt->second;
+    throw std::invalid_argument("Connection not found");
 }
 
-void ConnectionManager::stop(const Connection::Ptr& iConnection)
+std::string ConnectionManager::openConnection(const Connection::SocketPtr& ioSocket,
+                                              Connection::Callback& iCallback)
 {
-    std::cout << "[Manager] Stopping connection..." << std::endl;
-    connections.erase(iConnection);
-    iConnection->stop();
+    auto aConnection = std::make_shared<Connection>(ioSocket, iCallback);
+    size_t aPointerAdress = reinterpret_cast<size_t>(aConnection.get());
+    std::string aStrId = std::to_string(aPointerAdress);
+    connections.insert({ aStrId, aConnection });
+
+    std::cout << "[Manager] Opening connection [" << aStrId << "]" << std::endl;
+    aConnection->setId(aStrId);
+    aConnection->open();
+    return aStrId;
 }
 
-void ConnectionManager::stop_all()
+void ConnectionManager::closeConnection(const std::string& iConnectionId)
 {
-    std::cout << "[Manager] Stopping all connections..." << std::endl;
-    std::for_each (connections.begin(), connections.end(),
-                   boost::bind(&Connection::stop, _1));
+    std::cout << "[Manager] Closing connection [" << iConnectionId << "]..." << std::endl;
+    auto aIt = connections.find(iConnectionId);
+    if (aIt != std::end(connections))
+    {
+        aIt->second->close();
+        connections.erase(aIt);
+    }
+}
+
+void ConnectionManager::closeAll()
+{
+    std::cout << "[Manager] Closing all connections..." << std::endl;
+    for (auto aId2Connection : connections)
+        aId2Connection.second->close();
     connections.clear();
 }
 

--- a/src/memo/manager/ConnectionManager.hpp
+++ b/src/memo/manager/ConnectionManager.hpp
@@ -1,7 +1,7 @@
 #pragma once
 #include "memo/Connection.hpp"
 
-#include <set>
+#include <map>
 
 namespace memo {
 namespace manager {
@@ -11,19 +11,20 @@ class ConnectionManager
 public:
     ConnectionManager() = default;
 
-	void start(const Connection::Ptr& iConnection);
+    Connection& getConnectionById(const std::string& iId);
 
-  	/// Stop the specified connection.
-  	void stop(const Connection::Ptr& iConnection);
+    std::string openConnection(const Connection::SocketPtr& ioSocket,
+                               Connection::Callback& iCallback);
 
-  	/// Stop all connections.
-  	void stop_all();
+    void closeConnection(const std::string& iConnectionId);
+
+    void closeAll();
 
     ConnectionManager(const ConnectionManager&) = delete;
     ConnectionManager& operator=(const ConnectionManager&) = delete;
 
 private:
-    std::set<Connection::Ptr> connections;
+    std::map<std::string, Connection::Ptr> connections;
 };
 } // namespace memo
 } // namespace manager


### PR DESCRIPTION
- Connection has no longer access to the ConnectionManager
- Server now makes the decisions about when to open and close a Connection
- each Connection is now associated with an id, which is then communicated to the Server
- parsing and handling of the incoming data moved to the Server (Connection only reads raw data in a string and passes it to the Server)